### PR TITLE
#2905053 Drupal 8.4 compatibility.

### DIFF
--- a/current_page_crumb.services.yml
+++ b/current_page_crumb.services.yml
@@ -1,6 +1,6 @@
 services:
   current_page_crumb.breadcrumb:
     class: Drupal\current_page_crumb\BreadcrumbBuilder
-    arguments: ['@router.request_context', '@access_manager', '@router', '@path_processor_manager', '@config.factory',  '@title_resolver', '@current_user', '@path.current', '@menu.active_trail', '@plugin.manager.menu.link']
+    parent: system.breadcrumb.default
     tags:
       - { name: breadcrumb_builder, priority: 1 }


### PR DESCRIPTION
Inherit the arguments from the parent service. The additional added services aren't used anywhere and break Drupal 8.4 since the `Drupal\system\PathBasedBreadcrumbBuilder` service now has an additional argument.